### PR TITLE
Fix broken links for version 3.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -696,13 +696,13 @@ executable.</li>
 <div class="section" id="downloads">
 <h1>Downloads</h1>
 <p>The latest stable release of PyInstaller is 3.1
-(<a class="reference external" href="https://github.com/pyinstaller/pyinstaller/releases/tag/3.1">Change Log</a>).</p>
+(<a class="reference external" href="https://github.com/pyinstaller/pyinstaller/releases/tag/v3.1">Change Log</a>).</p>
 <ul>
 <li><p class="first"><strong>Release 3.1</strong>:</p>
 <p>Stable, supports Python 2.7, 3.3–3.5</p>
 <ul class="simple">
-<li><a class="reference external" href="https://github.com/pyinstaller/pyinstaller/releases/download/3.1/PyInstaller-3.1.tar.gz">PyInstaller 3.1 (tar.gz)</a> (sha-256: 5a28c3bb9d23ea644f9dc9e561e66471b83258d44063bcb108dfbbfe4af3c02b)</li>
-<li><a class="reference external" href="https://github.com/pyinstaller/pyinstaller/releases/download/3.1/PyInstaller-3.1.zip">PyInstaller 3.1 (zip)</a> (sha-256: 70be0d85e23c10bc016e9550d0686053ec00b97693291374282259cdd02d734b)</li>
+<li><a class="reference external" href="https://github.com/pyinstaller/pyinstaller/releases/download/v3.1/PyInstaller-3.1.tar.gz">PyInstaller 3.1 (tar.gz)</a> (sha-256: 5a28c3bb9d23ea644f9dc9e561e66471b83258d44063bcb108dfbbfe4af3c02b)</li>
+<li><a class="reference external" href="https://github.com/pyinstaller/pyinstaller/releases/download/v3.1/PyInstaller-3.1.zip">PyInstaller 3.1 (zip)</a> (sha-256: 70be0d85e23c10bc016e9550d0686053ec00b97693291374282259cdd02d734b)</li>
 </ul>
 </li>
 <li><p class="first"><strong>Development</strong>: supports Python 2.7, 3.3–3.5</p>
@@ -741,7 +741,7 @@ For a more detailed walkthrough, see the `manual
 <ul class="simple">
 <li>Documentation for version 3.1:
 <a class="reference external" href="http://pythonhosted.org/PyInstaller/">html</a>,
-<a class="reference external" href="https://github.com/pyinstaller/pyinstaller/blob/3.1/doc/Manual.pdf?raw=true">pdf</a></li>
+<a class="reference external" href="https://github.com/pyinstaller/pyinstaller/blob/v3.1/doc/Manual.pdf?raw=true">pdf</a></li>
 <li>Manual for development version:
 <a class="reference external" href="http://htmlpreview.github.io/?https://github.com/pyinstaller/pyinstaller/blob/develop/doc/Manual.html">html</a>,
 <a class="reference external" href="https://github.com/pyinstaller/pyinstaller/blob/develop/doc/Manual.pdf?raw=true">pdf</a>.</li>

--- a/index.rst
+++ b/index.rst
@@ -109,7 +109,7 @@ Downloads
 ================
 
 The latest stable release of PyInstaller is 3.1
-(`Change Log <https://github.com/pyinstaller/pyinstaller/releases/tag/3.1>`_).
+(`Change Log <https://github.com/pyinstaller/pyinstaller/releases/tag/v3.1>`_).
 
 
 * **Release 3.1**:
@@ -119,8 +119,8 @@ The latest stable release of PyInstaller is 3.1
   - `PyInstaller 3.1 (tar.gz)`__ (sha-256: 5a28c3bb9d23ea644f9dc9e561e66471b83258d44063bcb108dfbbfe4af3c02b)
   - `PyInstaller 3.1 (zip)`__ (sha-256: 70be0d85e23c10bc016e9550d0686053ec00b97693291374282259cdd02d734b)
 
-  __ https://github.com/pyinstaller/pyinstaller/releases/download/3.1/PyInstaller-3.1.tar.gz
-  __ https://github.com/pyinstaller/pyinstaller/releases/download/3.1/PyInstaller-3.1.zip
+  __ https://github.com/pyinstaller/pyinstaller/releases/download/v3.1/PyInstaller-3.1.tar.gz
+  __ https://github.com/pyinstaller/pyinstaller/releases/download/v3.1/PyInstaller-3.1.zip
 
 
 * **Development**: supports Python 2.7, 3.3–3.5
@@ -166,7 +166,7 @@ Documentation
 
 * Documentation for version 3.1:
   `html <http://pythonhosted.org/PyInstaller/>`__,
-  `pdf <https://github.com/pyinstaller/pyinstaller/blob/3.1/doc/Manual.pdf?raw=true>`__
+  `pdf <https://github.com/pyinstaller/pyinstaller/blob/v3.1/doc/Manual.pdf?raw=true>`__
 
 * Manual for development version:
   `html <http://htmlpreview.github.io/?https://github.com/pyinstaller/pyinstaller/blob/develop/doc/Manual.html>`__,


### PR DESCRIPTION
Like versions 2.1 and below, the tag has a “v” in its name :)
