### PR TITLE
Update supported python version of the main page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -14,7 +14,7 @@ Welcome to PyInstaller official website
 PyInstaller is a program that freezes (packages) Python programs into
 stand-alone executables, under Windows, Linux, Mac OS X, FreeBSD,
 Solaris and AIX. Its main advantages over similar tools are that
-PyInstaller works with Python 2.7 and 3.3—3.6, it builds smaller
+PyInstaller works with Python 2.7 and 3.3—3.7, it builds smaller
 executables thanks to transparent compression, it is fully
 multi-platform, and use the OS support to load the dynamic libraries,
 thus ensuring full compatibility.

--- a/index.rst
+++ b/index.rst
@@ -14,7 +14,7 @@ Welcome to PyInstaller official website
 PyInstaller is a program that freezes (packages) Python programs into
 stand-alone executables, under Windows, Linux, Mac OS X, FreeBSD,
 Solaris and AIX. Its main advantages over similar tools are that
-PyInstaller works with Python 2.7 and 3.3—3.7, it builds smaller
+PyInstaller works with Python 2.7 and 3.4—3.7, it builds smaller
 executables thanks to transparent compression, it is fully
 multi-platform, and use the OS support to load the dynamic libraries,
 thus ensuring full compatibility.


### PR DESCRIPTION
According to https://github.com/pyinstaller/pyinstaller the currently
supported version are 2.7 and 3.4-3.7.

The website currently says 2.7 and 3.3-3.6. I updated 3.6 to 3.7 as I'm using
pyinstaller latest release with 3.7 without issues but I'm not so sure about
3.4 so it's left untouched.